### PR TITLE
allow different ssh port than 22

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
+# set the ssh port
+ssh_port: 22
+
 # default users for SSH access
 sshd_default_allowed_users:
   - "root"

--- a/templates/sshd_config.j2
+++ b/templates/sshd_config.j2
@@ -3,7 +3,7 @@
 
 
 # Networking
-Port 22
+Port {{ ssh_port }}
 
 TCPKeepAlive yes
 


### PR DESCRIPTION
The majority of (automated) loginattacks on SSH are done on the standard port 22, so it might make sence to change the port.
Default port of the script stays 22